### PR TITLE
fix getOperation is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ MongoMock.max_delay = 0;
 const validationErrors = async (db, collectionName, { doc, err }) => {
   const collectionInfo = await db.command({ listCollections: 1, filter: { name: collectionName } });
   const schema = collectionInfo.cursor.firstBatch[0].options.validator.$jsonSchema;
-  if (!doc) {
+  if (!doc && err) {
     doc = (`op` in err) ? err.op : err.getOperation(); // eslint-disable-line no-param-reassign
   }
   const valid = ajv.validate(schema, doc);

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ MongoMock.max_delay = 0;
 const validationErrors = async (db, collectionName, { doc, err }) => {
   const collectionInfo = await db.command({ listCollections: 1, filter: { name: collectionName } });
   const schema = collectionInfo.cursor.firstBatch[0].options.validator.$jsonSchema;
-  if (!doc && err) {
-    doc = err.getOperation(); // eslint-disable-line no-param-reassign
+  if (!doc) {
+    doc = (`op` in err) ? err.op : err.getOperation(); // eslint-disable-line no-param-reassign
   }
   const valid = ajv.validate(schema, doc);
   return { valid, errors: ajv.errors };


### PR DESCRIPTION
When running insertMany I receive: 

`(node:82873) UnhandledPromiseRejectionWarning: TypeError: err.getOperation is not a function
    at validationErrors (.../node_modules/mongo-schemer/index.js:19:15)
    at process._tickCallback (internal/process/next_tick.js:68:7)`

The error object contains an `op` key which serves the same purpose as `err.getOperation`. This PR suggests using `err.op` if it exists and else falling back to `err.getOperation()`. Mongo Schemer works as expected in our tests with this change.

This is with mongodb v.3.1.13