### PR TITLE
fix(mongo mock db): close db connection after use

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,8 @@ const explainSchemaErrors = (incomingDb, options = {}) => {
           err.validationErrors = await explainValidationError(db, collectionName, { doc });
           // Clean up MongoMock
           await mockCol.removeOne(...uoArgs);
+          // close MongoMock DB connection
+          mockDb.close();
         }
         throw err;
       }
@@ -111,6 +113,8 @@ const explainSchemaErrors = (incomingDb, options = {}) => {
           err.validationErrors = [].concat(...errorLists);
           // Clean up MongoMock
           await mockCol.removeMany(...umArgs);
+          // close MongoMock DB connection
+          mockDb.close();
         }
         throw err;
       }
@@ -135,6 +139,8 @@ const explainSchemaErrors = (incomingDb, options = {}) => {
           err.validationErrors = await explainValidationError(db, collectionName, { doc });
           // Clean up MongoMock
           await mockCol.removeOne(...uoArgs);
+          // close MongoMock DB connection
+          mockDb.close();
         }
         throw err;
       }


### PR DESCRIPTION
Believe this avoids a memory leak as Mongo Mock DB connections are currently left hanging.

I do not believe it is possible to easily cover this with tests but more than happy to do so if you have any ideas?

Many thanks! Matthew