### PR TITLE
WIP: support MongoDB transaction edge case

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,20 +75,24 @@ const explainSchemaErrors = (incomingDb, options = {}) => {
         if (err && err.code === 121) {
           // Get doc we're trying to update
           const currentDoc = await col.findOne(uoArgs[0]);
-          // Load current doc into mock mongo
-          const mockDb = await MongoMock.MongoClient.connect(MongoMockUrl);
-          const mockCol = mockDb.collection('mock');
-          await mockCol.insertOne(currentDoc);
-          // Apply updates to our mock version of the current doc
-          await mockCol.updateOne(...uoArgs);
-          // Get updated doc from mock mongo to compare against schema
-          const doc = await mockCol.findOne(uoArgs[0]);
-          // Explain schema errors
-          err.validationErrors = await explainValidationError(db, collectionName, { doc });
-          // Clean up MongoMock
-          await mockCol.removeOne(...uoArgs);
-          // close MongoMock DB connection
-          mockDb.close();
+          // If doc created & updated in same MongoDB transaction enhanced validation details cannot be provided as
+          // validation errors roll back transactions leaving us with no knowledge of the originally created valid doc
+          if (currentDoc) {
+            // Load current doc into mock mongo
+            const mockDb = await MongoMock.MongoClient.connect(MongoMockUrl);
+            const mockCol = mockDb.collection('mock');
+            await mockCol.insertOne(currentDoc);
+            // Apply updates to our mock version of the current doc
+            await mockCol.updateOne(...uoArgs);
+            // Get updated doc from mock mongo to compare against schema
+            const doc = await mockCol.findOne(uoArgs[0]);
+            // Explain schema errors
+            err.validationErrors = await explainValidationError(db, collectionName, { doc });
+            // Clean up MongoMock
+            await mockCol.removeOne(...uoArgs);
+            // close MongoMock DB connection
+            mockDb.close();
+          }
         }
         throw err;
       }
@@ -101,20 +105,24 @@ const explainSchemaErrors = (incomingDb, options = {}) => {
         if (err && err.code === 121) {
           // Get docs we're trying to update
           const currentDocs = await col.find(umArgs[0]).toArray();
-          // Load current docs into mock mongo
-          const mockDb = await MongoMock.MongoClient.connect(MongoMockUrl);
-          const mockCol = mockDb.collection('mock');
-          await mockCol.insertMany(currentDocs);
-          // Apply updates to our mock version of the current docs
-          await mockCol.updateMany(...umArgs);
-          // Get updated docs from mock mongo to compare against schema
-          const docs = await mockCol.find(umArgs[0]).toArray();
-          const errorLists = await Promise.all(docs.map(doc => explainValidationError(db, collectionName, { doc })));
-          err.validationErrors = [].concat(...errorLists);
-          // Clean up MongoMock
-          await mockCol.removeMany(...umArgs);
-          // close MongoMock DB connection
-          mockDb.close();
+          // If all docs created & updated in same MongoDB transaction enhanced validation details cannot be provided as
+          // validation errors roll back transactions leaving us with no knowledge of the originally created valid docs
+          if (currentDocs.length > 0) {
+            // Load current docs into mock mongo
+            const mockDb = await MongoMock.MongoClient.connect(MongoMockUrl);
+            const mockCol = mockDb.collection('mock');
+            await mockCol.insertMany(currentDocs);
+            // Apply updates to our mock version of the current docs
+            await mockCol.updateMany(...umArgs);
+            // Get updated docs from mock mongo to compare against schema
+            const docs = await mockCol.find(umArgs[0]).toArray();
+            const errorLists = await Promise.all(docs.map(doc => explainValidationError(db, collectionName, { doc })));
+            err.validationErrors = [].concat(...errorLists);
+            // Clean up MongoMock
+            await mockCol.removeMany(...umArgs);
+            // close MongoMock DB connection
+            mockDb.close();
+          }
         }
         throw err;
       }
@@ -127,20 +135,24 @@ const explainSchemaErrors = (incomingDb, options = {}) => {
         if (err && err.code === 121) {
           // Get doc we're trying to update
           const currentDoc = await col.findOne(uoArgs[0]);
-          // Load current doc into mock mongo
-          const mockDb = await MongoMock.MongoClient.connect(MongoMockUrl);
-          const mockCol = mockDb.collection('mock');
-          await mockCol.insertOne(currentDoc);
-          // Apply updates to our mock version of the current doc
-          await mockCol.findOneAndUpdate(...uoArgs);
-          // Get updated doc from mock mongo to compare against schema
-          const doc = await mockCol.findOne(uoArgs[0]);
-          // Explain schema errors
-          err.validationErrors = await explainValidationError(db, collectionName, { doc });
-          // Clean up MongoMock
-          await mockCol.removeOne(...uoArgs);
-          // close MongoMock DB connection
-          mockDb.close();
+          // If doc created & updated in same MongoDB transaction enhanced validation details cannot be provided as
+          // validation errors roll back transactions leaving us with no knowledge of the originally created valid doc
+          if (currentDoc) {
+            // Load current doc into mock mongo
+            const mockDb = await MongoMock.MongoClient.connect(MongoMockUrl);
+            const mockCol = mockDb.collection('mock');
+            await mockCol.insertOne(currentDoc);
+            // Apply updates to our mock version of the current doc
+            await mockCol.findOneAndUpdate(...uoArgs);
+            // Get updated doc from mock mongo to compare against schema
+            const doc = await mockCol.findOne(uoArgs[0]);
+            // Explain schema errors
+            err.validationErrors = await explainValidationError(db, collectionName, { doc });
+            // Clean up MongoMock
+            await mockCol.removeOne(...uoArgs);
+            // close MongoMock DB connection
+            mockDb.close();
+          }
         }
         throw err;
       }

--- a/spec/validate.spec.js
+++ b/spec/validate.spec.js
@@ -247,55 +247,6 @@ describe('Mongo Explain Validate Errors', () => {
       }
     }
   });
-
-  it('does not explain updateOne validation error due to doc also being created within transaction', async (done) => {
-    let session;
-    const col = db.collection(collectionName);
-
-    try {
-      session = client.startSession();
-      session.startTransaction();
-      await col.insertOne({
-        name: 'testUpdateOneTransaction',
-        type: 'first',
-        created: new Date(),
-        items: [
-          {
-            description: 'First item',
-          },
-        ],
-      }, {
-        session,
-      });
-    } catch (err) {
-      done.fail('Failed with non-validation error');
-    }
-
-
-    db.onValidationError = (errors) => {
-      expect(errors.length).toBe(1);
-      expect(errors[0].keyword).toBe('bsonType');
-      expect(errors[0].dataPath).toBe('.created');
-      done();
-    };
-    try {
-      await col.updateOne({
-        name: 'testUpdateOneTransaction',
-      }, {
-        $set: {
-          created: 'this should be a date instead',
-        },
-      }, {
-        session,
-      });
-      done();
-    } catch (err) {
-      if (err.code !== 121) {
-        done.fail('Failed with non-validation error');
-      }
-    }
-  });
-
   it('explains updateMany validation error', async (done) => {
     const col = db.collection(collectionName);
     let errorsReported = 0;

--- a/spec/validate.spec.js
+++ b/spec/validate.spec.js
@@ -247,6 +247,55 @@ describe('Mongo Explain Validate Errors', () => {
       }
     }
   });
+
+  it('does not explain updateOne validation error due to doc also being created within transaction', async (done) => {
+    let session;
+    const col = db.collection(collectionName);
+
+    try {
+      session = client.startSession();
+      session.startTransaction();
+      await col.insertOne({
+        name: 'testUpdateOneTransaction',
+        type: 'first',
+        created: new Date(),
+        items: [
+          {
+            description: 'First item',
+          },
+        ],
+      }, {
+        session,
+      });
+    } catch (err) {
+      done.fail('Failed with non-validation error');
+    }
+
+
+    db.onValidationError = (errors) => {
+      expect(errors.length).toBe(1);
+      expect(errors[0].keyword).toBe('bsonType');
+      expect(errors[0].dataPath).toBe('.created');
+      done();
+    };
+    try {
+      await col.updateOne({
+        name: 'testUpdateOneTransaction',
+      }, {
+        $set: {
+          created: 'this should be a date instead',
+        },
+      }, {
+        session,
+      });
+      done();
+    } catch (err) {
+      if (err.code !== 121) {
+        done.fail('Failed with non-validation error');
+      }
+    }
+  });
+
   it('explains updateMany validation error', async (done) => {
     const col = db.collection(collectionName);
     let errorsReported = 0;


### PR DESCRIPTION
**ISSUE**
If a document is created & updated in the same MongoDB transaction enhanced validation details cannot be provided as validation errors roll back transactions removing the initially created (and valid) document. At this point there is no way to know what the originally created valid document was. This leads to `currentDoc` not existing and causes uncaught errors.

**SUGGESTED FIX**
This PR fixes this by checking if `currentDoc` is truthy. 

**TESTING**
Attempted to add tests for this, however, in order to use MongoDB transactions you have to use a replica set which seems quite hard to do locally. I have however tested it against our internal API (thousands of tests - we use a live MongoDB Atlas cluster for our internal tests) which all pass (this is how we found this bug). I suggest that this change goes in without tests covering this specific scenario as the change is a safety net in any case (in which case this PR is ready). If tests are required I am not sure quite how to proceed as I believe it would involve a fairly large change to the test setup.